### PR TITLE
fix: remove ffmpeg-free from all images (#582)

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -170,6 +170,7 @@
         },
         "exclude": {
             "all": [
+                "ffmpeg-free",
                 "google-noto-sans-cjk-vf-fonts",
                 "libavcodec-free",
                 "libavdevice-free",


### PR DESCRIPTION
## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/CONTRIBUTING/) before submitting a pull request.
